### PR TITLE
Small fix in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 Add the following line to your `Podfile`:
 
-```
+```ruby
 pod 'InAppViewDebugger', '~> 1.0.1'
 ```
 
@@ -124,7 +124,11 @@ Colors, fonts, and other attributes for both the snapshot view and the hierarchy
 
 The current implementation only supports `UIView` hierarchies, but this can easily be extended to support other UI frameworks by conforming to the [`Element`](blob/master/InAppViewDebugger/Element.swift) protocol. See [`ViewElement`](blob/master/InAppViewDebugger/ViewElement.swift) to see what an example implementation looks like — by providing a the frame, a snapshot image, and a few other pieces of information, all of the features described above will work for your own framework.
 
-A [`Snapshot`](blob/master/InAppViewDebugger/Snapshot.swift) instance represents a recursive snapshot of the *current state* of a UI element hierarchy, and is constructed using an `Element`. The snapshot can then be passed to `InAppViewDebugger.presentWithSnapshot(:rootViewController:configuration:completion:` to show the view debugger.
+A [`Snapshot`](blob/master/InAppViewDebugger/Snapshot.swift) instance represents a recursive snapshot of the *current state* of a UI element hierarchy, and is constructed using an `Element`. The snapshot can then be passed to
+```swift
+InAppViewDebugger.presentWithSnapshot(:rootViewController:configuration:completion: 
+```
+to show the view debugger.
 
 ## Credits
 


### PR DESCRIPTION
Function `InAppViewDebugger.presentWithSnapshot` so long and transfers text to new line. Set this test as code. Also set `ruby` for pod-line. 