### PR TITLE
Fix crash on iOS 17 using UIGraphicsBeginImageContext

### DIFF
--- a/InAppViewDebugger/ViewElement.swift
+++ b/InAppViewDebugger/ViewElement.swift
@@ -78,11 +78,11 @@ fileprivate func getViewController(view: UIView) -> UIViewController? {
 }
 
 fileprivate func drawView(_ view: UIView) -> CGImage? {
-    UIGraphicsBeginImageContextWithOptions(view.bounds.size, false, 0)
-    view.drawHierarchy(in: view.bounds, afterScreenUpdates: true)
-    let image = UIGraphicsGetImageFromCurrentImageContext()
-    UIGraphicsEndImageContext()
-    return image?.cgImage
+    let renderer = UIGraphicsImageRenderer(size: view.bounds.size)
+    let image = renderer.image { context in
+        view.drawHierarchy(in: view.bounds, afterScreenUpdates: true)
+    }
+    return image.cgImage
 }
 
 fileprivate func hideViewsOnTopOf(view: UIView, root: UIView, hiddenViews: inout [UIView]) -> Bool {


### PR DESCRIPTION
iOS 17 crashes in Simulator and on Device when using `UIGraphicsBeginImageContextWithOptions()`:

```
*** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'UIGraphicsBeginImageContext() failed to allocate CGBitampContext: size={264.66666666666669, 0}, scale=3.000000, bitmapInfo=0x2002. Use UIGraphicsImageRenderer to avoid this assert.'
*** First throw call stack:
(
	0   CoreFoundation                      0x00000001804658a8 __exceptionPreprocess + 172
	1   libobjc.A.dylib                     0x000000018005c09c objc_exception_throw + 56
	2   Foundation                          0x0000000180cf3b90 -[NSMutableDictionary(NSMutableDictionary) classForCoder] + 0
	3   UIKitCore                           0x0000000157aecf68 _UIGraphicsBeginImageContextWithOptions + 564
	4   xxx                            0x0000000115affb68 $s17InAppViewDebugger04drawC033_35665C788565EC8EA16D4ADA6DBE861FLLySo10CGImageRefaSgSo6UIViewCF + 128
	5   xxx                            0x0000000115afeba8 $s17InAppViewDebugger08snapshotC033_35665C788565EC8EA16D4ADA6DBE861FLLySo10CGImageRefaSgSo6UIViewCF + 1248
	6   xxx                            0x0000000115afe680 $s17InAppViewDebugger0C7ElementC13snapshotImageSo10CGImageRefaSgvg + 164
	7   xxx                            0x0000000115afe5b8 $s17InAppViewDebugger0C7ElementC13snapshotImageSo10CGImageRefaSgvgTo + 36
	8   xxx                            0x0000000115ae87a4 $s17InAppViewDebugger8SnapshotC7elementAcA7Element_p_tcfc + 772
	9   xxx                            0x0000000115ae80bc $s17InAppViewDebugger8SnapshotC7elementAcA7Element_p_tcfC + 40
	10  xxx                            0x0000000115ae898c $s17InAppViewDebugger8SnapshotC7elementAcA7Element_p_tcfcAcaE_pXEfU_ + 84
libc++abi: terminating due to uncaught exception of type NSException
```